### PR TITLE
Silenced CURL outputting response to stdout

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -20,6 +20,11 @@ JSON body:
 
 */
 
+size_t silent_stream_handler(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+   return size * nmemb;
+}
+
 static void stats_pusher_datadog(struct uwsgi_stats_pusher_instance *uspi, time_t now, char *json, size_t json_len) {
 
 	// we use the same buffer for all of the metrics
@@ -79,6 +84,7 @@ static void stats_pusher_datadog(struct uwsgi_stats_pusher_instance *uspi, time_
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, ub->buf);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &silent_stream_handler);  // disable CURL output to stdout
         CURLcode res = curl_easy_perform(curl);
         curl_slist_free_all(headers);
         if (res != CURLE_OK) {


### PR DESCRIPTION
When running the plugin through uwsgi, stdout is being written with CURL response body, each time the request is being executed. This is unexpected behavior since it collides with console and logs leaving lots of unneeded messages. This fix redirects stdout of curl so output of uwsgi doesn't get affected with this undesired outputs. Would it be possible if anybody from uwsgi team have a look?